### PR TITLE
Fix race conditions in DHCP test

### DIFF
--- a/plugins/ipam/dhcp/dhcp_test.go
+++ b/plugins/ipam/dhcp/dhcp_test.go
@@ -332,9 +332,17 @@ var _ = Describe("DHCP Operations", func() {
 					started.Done()
 					started.Wait()
 
-					err = originalNS.Do(func(ns.NetNS) error {
+					err := originalNS.Do(func(ns.NetNS) error {
 						return testutils.CmdDelWithArgs(args, func() error {
-							return cmdDel(args)
+							copiedArgs := &skel.CmdArgs{
+								ContainerID: args.ContainerID,
+								Netns:       args.Netns,
+								IfName:      args.IfName,
+								StdinData:   args.StdinData,
+								Path:        args.Path,
+								Args:        args.Args,
+							}
+							return cmdDel(copiedArgs)
 						})
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -15,7 +15,7 @@ source ./build_linux.sh
 echo "Running tests"
 
 function testrun {
-    sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test $@"
+    sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race $@"
 }
 
 COVERALLS=${COVERALLS:-""}
@@ -31,7 +31,7 @@ PKG=${PKG:-$(go list ./... | xargs echo)}
 i=0
 for t in ${PKG}; do
     if [ -n "${COVERALLS}" ]; then
-        COVERFLAGS="-covermode set -coverprofile ${i}.coverprofile"
+        COVERFLAGS="-covermode atomic -coverprofile ${i}.coverprofile"
     fi
     echo "${t}"
     testrun "${COVERFLAGS:-""} ${t}"

--- a/test_windows.sh
+++ b/test_windows.sh
@@ -17,4 +17,4 @@ for d in $PLUGINS; do
 done
 
 echo "testing packages $PKGS"
-go test -v $PKGS -ginkgo.randomizeAllSpecs -ginkgo.failOnPending -ginkgo.progress
+go test -race -v $PKGS -ginkgo.randomizeAllSpecs -ginkgo.failOnPending -ginkgo.progress


### PR DESCRIPTION
The test named "correctly handles multiple DELs for the same container" in the ipam/dhcp package experiences race conditions when multiple goroutines concurrently access and modify the Args struct (of type CmdArgs). To address these issues, a copy of the CmdArgs struct is now created in each function to eliminate data races.

Also, the test-linux.sh and test-windows.sh scripts have been updated to include the '-race' flag, enabling race detection during testing. This change helps prevent future race conditions by activating the Go race detector.